### PR TITLE
fix ModuleNotFoundError: No module named 'six'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="ITBM"
 RUN apk update \
 	&& apk add coreutils \
 	&& apk add postgresql-client \
-	&& apk add python3 py3-pip && pip3 install awscli && apk del py3-pip \
+	&& apk add python3 py3-pip && pip3 install --upgrade pip && pip3 install awscli \
 	&& apk add openssl \
 	&& apk add curl \
 	&& curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron && chmod u+x /usr/local/bin/go-cron \


### PR DESCRIPTION
I've got this error today when was trying to setup backup, was able to fix it this way. I understand that it will increace image but at least it works now.

postgresql-backup-s3_1  | Traceback (most recent call last):
postgresql-backup-s3_1  |   File "/usr/bin/aws", line 19, in <module>
postgresql-backup-s3_1  |     import awscli.clidriver
postgresql-backup-s3_1  |   File "/usr/lib/python3.8/site-packages/awscli/clidriver.py", line 17, in <module>
postgresql-backup-s3_1  |     import botocore.session
postgresql-backup-s3_1  |   File "/usr/lib/python3.8/site-packages/botocore/session.py", line 29, in <module>
postgresql-backup-s3_1  |     import botocore.configloader
postgresql-backup-s3_1  |   File "/usr/lib/python3.8/site-packages/botocore/configloader.py", line 19, in <module>
postgresql-backup-s3_1  |     from botocore.compat import six
postgresql-backup-s3_1  |   File "/usr/lib/python3.8/site-packages/botocore/compat.py", line 26, in <module>
postgresql-backup-s3_1  |     from dateutil.tz import tzlocal
postgresql-backup-s3_1  |   File "/usr/lib/python3.8/site-packages/dateutil/tz/__init__.py", line 2, in <module>
postgresql-backup-s3_1  |     from .tz import *
postgresql-backup-s3_1  |   File "/usr/lib/python3.8/site-packages/dateutil/tz/tz.py", line 19, in <module>
postgresql-backup-s3_1  |     import six
postgresql-backup-s3_1  | ModuleNotFoundError: No module named 'six'