### PR TITLE
add postgres 14 support with lighter image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
-FROM alpine:3.13
+FROM alpine:3.15
 LABEL maintainer="ITBM"
 
 RUN apk update \
-	&& apk add coreutils \
-	&& apk add postgresql-client \
-	&& apk add python3 py3-pip && pip3 install --upgrade pip && pip3 install awscli \
-	&& apk add openssl \
-	&& apk add curl \
+	&& apk add postgresql14-client \
 	&& curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron && chmod u+x /usr/local/bin/go-cron \
 	&& apk del curl \
 	&& rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM alpine:3.15
 LABEL maintainer="ITBM"
 
 RUN apk update \
-	&& apk add postgresql14-client \
+	&& apk add --no-cache coreutils \
+	&& apk add --no-cache postgresql14-client \
+	&& apk add --no-cache python3 py3-pip && pip3 install --upgrade pip && pip3 install awscli \
+	&& apk add --no-cache openssl \
+	&& apk add --no-cache curl \
 	&& curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron && chmod u+x /usr/local/bin/go-cron \
 	&& apk del curl \
 	&& rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM alpine:3.15
+
+FROM alpine:3.15 as base
+
+RUN apk add --no-cache curl \
+	&& curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron && chmod u+x /usr/local/bin/go-cron
+
+FROM python:3.9-alpine3.15
 LABEL maintainer="ITBM"
 
-RUN apk update \
-	&& apk add --no-cache coreutils \
-	&& apk add --no-cache postgresql14-client \
-	&& apk add --no-cache python3 py3-pip && pip3 install --upgrade pip && pip3 install awscli \
-	&& apk add --no-cache openssl \
-	&& apk add --no-cache curl \
-	&& curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron && chmod u+x /usr/local/bin/go-cron \
-	&& apk del curl \
-	&& rm -rf /var/cache/apk/*
+RUN apk add --no-cache postgresql14-client openssl \
+	&& pip3 --no-cache-dir install awscli \
+	&& rm -fr /root/.cache
+
+COPY --from=base --chmod=u+x /usr/local/bin/go-cron /usr/local/bin/go-cron
 
 ENV POSTGRES_DATABASE **None**
 ENV POSTGRES_HOST **None**
@@ -28,7 +30,6 @@ ENV SCHEDULE **None**
 ENV ENCRYPTION_PASSWORD **None**
 ENV DELETE_OLDER_THAN **None**
 
-ADD run.sh run.sh
-ADD backup.sh backup.sh
+ADD *.sh .
 
 CMD ["sh", "run.sh"]


### PR DESCRIPTION
This MR adds support of postgres 14 with latest alpine version.

Before: Total Image size: 166 MB
After: Total Image size: 140 MB

I'm unsure for what `coreutils` is used for.

You can test this image directly from my docker hub : nevax/postgresql-backup-s3

