### PR TITLE
Restore script, PBKDF2, and dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.13
+FROM alpine:3.15
 LABEL maintainer="ITBM"
 
 RUN apk update \
 	&& apk add coreutils \
-	&& apk add postgresql-client \
+	&& apk add postgresql14-client \
 	&& apk add python3 py3-pip && pip3 install --upgrade pip && pip3 install awscli \
 	&& apk add openssl \
 	&& apk add curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ ENV ENCRYPTION_PASSWORD **None**
 ENV DELETE_OLDER_THAN **None**
 
 ADD run.sh run.sh
+ADD common.sh common.sh
 ADD backup.sh backup.sh
+ADD restore.sh restore.sh
 
 CMD ["sh", "run.sh"]

--- a/README.md
+++ b/README.md
@@ -98,3 +98,15 @@ WARNING: this will delete all files in the S3_PREFIX path, not just those create
 ### Encryption
 
 You can additionally set the `ENCRYPTION_PASSWORD` environment variable like `-e ENCRYPTION_PASSWORD="superstrongpassword"` to encrypt the backup. It can be decrypted using `openssl aes-256-cbc -d -in backup.sql.gz.enc -out backup.sql.gz`.
+
+
+### Restoring data from backup
+
+If you need to restore data, start the backup container, find the container name
+or ID, then run:
+
+```
+docker exec -it ${CONTAINER} /bin/sh /restore.sh
+```
+
+The latest backup will be found and restored.

--- a/backup.sh
+++ b/backup.sh
@@ -1,63 +1,5 @@
 #! /bin/sh
-
-set -e
-set -o pipefail
-
->&2 echo "-----"
-
-if [ "${S3_ACCESS_KEY_ID}" = "**None**" ]; then
-  echo "You need to set the S3_ACCESS_KEY_ID environment variable."
-  exit 1
-fi
-
-if [ "${S3_SECRET_ACCESS_KEY}" = "**None**" ]; then
-  echo "You need to set the S3_SECRET_ACCESS_KEY environment variable."
-  exit 1
-fi
-
-if [ "${S3_BUCKET}" = "**None**" ]; then
-  echo "You need to set the S3_BUCKET environment variable."
-  exit 1
-fi
-
-if [ "${POSTGRES_DATABASE}" = "**None**" ]; then
-  echo "You need to set the POSTGRES_DATABASE environment variable."
-  exit 1
-fi
-
-if [ "${POSTGRES_HOST}" = "**None**" ]; then
-  if [ -n "${POSTGRES_PORT_5432_TCP_ADDR}" ]; then
-    POSTGRES_HOST=$POSTGRES_PORT_5432_TCP_ADDR
-    POSTGRES_PORT=$POSTGRES_PORT_5432_TCP_PORT
-  else
-    echo "You need to set the POSTGRES_HOST environment variable."
-    exit 1
-  fi
-fi
-
-if [ "${POSTGRES_USER}" = "**None**" ]; then
-  echo "You need to set the POSTGRES_USER environment variable."
-  exit 1
-fi
-
-if [ "${POSTGRES_PASSWORD}" = "**None**" ]; then
-  echo "You need to set the POSTGRES_PASSWORD environment variable or link to a container named POSTGRES."
-  exit 1
-fi
-
-if [ "${S3_ENDPOINT}" == "**None**" ]; then
-  AWS_ARGS=""
-else
-  AWS_ARGS="--endpoint-url ${S3_ENDPOINT}"
-fi
-
-# env vars needed for aws tools
-export AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY
-export AWS_DEFAULT_REGION=$S3_REGION
-
-export PGPASSWORD=$POSTGRES_PASSWORD
-POSTGRES_HOST_OPTS="-h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER $POSTGRES_EXTRA_OPTS"
+source common.sh
 
 echo "Creating dump of ${POSTGRES_DATABASE} database from ${POSTGRES_HOST}..."
 
@@ -82,7 +24,7 @@ if [ "${ENCRYPTION_PASSWORD}" != "**None**" ]; then
   DEST_FILE="${DEST_FILE}.enc"
 fi
 
-echo "Uploading dump to $S3_BUCKET"
+echo "Uploading ${DEST_FILE} to S3 ($S3_BUCKET)"
 
 cat $SRC_FILE | aws $AWS_ARGS s3 cp - s3://$S3_BUCKET/$S3_PREFIX/$DEST_FILE || exit 2
 

--- a/backup.sh
+++ b/backup.sh
@@ -73,7 +73,7 @@ fi
 
 if [ "${ENCRYPTION_PASSWORD}" != "**None**" ]; then
   >&2 echo "Encrypting ${SRC_FILE}"
-  openssl enc -aes-256-cbc -in $SRC_FILE -out ${SRC_FILE}.enc -k $ENCRYPTION_PASSWORD
+  openssl enc -aes-256-cbc -in $SRC_FILE -out ${SRC_FILE}.enc -pbkdf2 -k $ENCRYPTION_PASSWORD
   if [ $? != 0 ]; then
     >&2 echo "Error encrypting ${SRC_FILE}"
   fi

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,58 @@
+set -e
+set -o pipefail
+
+>&2 echo "-----"
+
+if [ "${S3_ACCESS_KEY_ID}" = "**None**" ]; then
+  echo "You need to set the S3_ACCESS_KEY_ID environment variable."
+  exit 1
+fi
+
+if [ "${S3_SECRET_ACCESS_KEY}" = "**None**" ]; then
+  echo "You need to set the S3_SECRET_ACCESS_KEY environment variable."
+  exit 1
+fi
+
+if [ "${S3_BUCKET}" = "**None**" ]; then
+  echo "You need to set the S3_BUCKET environment variable."
+  exit 1
+fi
+
+if [ "${POSTGRES_DATABASE}" = "**None**" ]; then
+  echo "You need to set the POSTGRES_DATABASE environment variable."
+  exit 1
+fi
+
+if [ "${POSTGRES_HOST}" = "**None**" ]; then
+  if [ -n "${POSTGRES_PORT_5432_TCP_ADDR}" ]; then
+    POSTGRES_HOST=$POSTGRES_PORT_5432_TCP_ADDR
+    POSTGRES_PORT=$POSTGRES_PORT_5432_TCP_PORT
+  else
+    echo "You need to set the POSTGRES_HOST environment variable."
+    exit 1
+  fi
+fi
+
+if [ "${POSTGRES_USER}" = "**None**" ]; then
+  echo "You need to set the POSTGRES_USER environment variable."
+  exit 1
+fi
+
+if [ "${POSTGRES_PASSWORD}" = "**None**" ]; then
+  echo "You need to set the POSTGRES_PASSWORD environment variable or link to a container named POSTGRES."
+  exit 1
+fi
+
+if [ "${S3_ENDPOINT}" == "**None**" ]; then
+  AWS_ARGS=""
+else
+  AWS_ARGS="--endpoint-url ${S3_ENDPOINT}"
+fi
+
+# env vars needed for aws tools
+export AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION=$S3_REGION
+
+export PGPASSWORD=$POSTGRES_PASSWORD
+POSTGRES_HOST_OPTS="-h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER $POSTGRES_EXTRA_OPTS"

--- a/restore.sh
+++ b/restore.sh
@@ -1,0 +1,38 @@
+#! /bin/sh
+source common.sh
+
+echo "Retstoring database ${POSTGRES_DATABASE} to ${POSTGRES_HOST} ..."
+
+echo "Finding latest backup ... "
+
+LATEST_BACKUP=$(aws $AWS_ARGS s3 ls s3://$S3_BUCKET/$S3_PREFIX/ | sort | tail -n 1 | awk '{ print $4 }')
+
+echo "Fetching ${LATEST_BACKUP} from S3"
+
+if [ "${ENCRYPTION_PASSWORD}" != "**None**" ]; then
+    aws $AWS_ARGS s3 cp s3://$S3_BUCKET/$S3_PREFIX/${LATEST_BACKUP} dump.sql.gz.enc
+    >&2 echo "Decrypting dump.sql.gz.enc"
+    openssl enc -aes-256-cbc -in dump.sql.gz.enc -out dump.sql.gz -pbkdf2 -d -k $ENCRYPTION_PASSWORD
+    rm dump.sql.gz.enc
+else
+    aws $AWS_ARGS s3 cp s3://$S3_BUCKET/$S3_PREFIX/${LATEST_BACKUP} dump.sql.gz
+fi
+
+gzip -f -d dump.sql.gz
+
+if [ "${DROP_PUBLIC}" == "yes" ]; then
+	echo "Recreating the public schema"
+	psql $POSTGRES_HOST_OPTS -d $POSTGRES_DATABASE -c "drop schema public cascade; create schema public;"
+fi
+
+echo "Restoring ${LATEST_BACKUP}"
+
+if [ "${POSTGRES_DATABASE}" == "all" ]; then
+    (set -x; psql $POSTGRES_HOST_OPTS < dump.sql)
+else
+    (set -x; psql $POSTGRES_HOST_OPTS -d $POSTGRES_DATABASE < dump.sql)
+fi
+
+echo "Restore complete"
+
+>&2 echo "-----"


### PR DESCRIPTION
Thanks very much for this script, I've been hacking on it for the past few days. I've got some updates you may wish to re-incorporate in your branch. Sorry, they're all here in one branch together:

 * Updates to alpine 3.15
 * Updates to postgresql14-client
 * Makes new restore script (fixes #7)
 * Introduces common.sh for parts common to both backup and restore
 * Turns on PBKF2 key derivation.

Before turning on PBKF2 I was seeing this warning (and now with this patch is absent):

```
2022/01/22 03:09:00 12: *** WARNING : deprecated key derivation used.
Using -iter or -pbkdf2 would be better.
```