### PR TITLE
Update go-cron to a crocosom/go-cron fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="ITBM"
 RUN apk update \
 	&& apk upgrade \
 	&& apk add coreutils postgresql16-client aws-cli openssl curl \
-	&& curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.7/go-cron-linux.gz | zcat > /usr/local/bin/go-cron \
+	&& curl -L --insecure https://github.com/crocosom/go-cron/releases/download/v0.2.8/go-cron_0.2.8_linux_amd64.tar.gz | tar -xzO go-cron > /usr/local/bin/go-cron \
  	&& chmod u+x /usr/local/bin/go-cron \
 	&& apk del curl \
 	&& rm -rf /var/cache/apk/*


### PR DESCRIPTION
The current version of go-cron does not work and produce the following errors:

```
$ docker run itbm/postgresql-backup-s3 go-cron "@daily" /bin/bash -c "echo 1"
Unable to find image 'itbm/postgresql-backup-s3:latest' locally
latest: Pulling from itbm/postgresql-backup-s3
Digest: sha256:8913559e64032f054d4d30ad8b2b06bbde951741a42a39e1cef93d3d073d1b80
Status: Downloaded newer image for itbm/postgresql-backup-s3:latest
2024/06/27 11:09:00 Running version: 6f160c2
panic: runtime error: slice bounds out of range

goroutine 16 [running]:
runtime.panic(0x6908e0, 0x8474af)
        /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/panic.c:279 +0xf5
main.main()
        /Users/jan/Documents/code/go/src/github.com/odise/go-cron/bin/go-cron.go:34 +0x6e7

goroutine 19 [finalizer wait]:
runtime.park(0x413a60, 0x84b508, 0x849749)
        /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1369 +0x89
runtime.parkunlock(0x84b508, 0x849749)
        /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1385 +0x3b
runfinq()
        /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/mgc0.c:2644 +0xcf
runtime.goexit()
        /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1445

goroutine 20 [syscall]:
os/signal.loop()
        /usr/local/Cellar/go/1.3.3/libexec/src/pkg/os/signal/signal_unix.go:21 +0x1e
created by os/signal.init·1
        /usr/local/Cellar/go/1.3.3/libexec/src/pkg/os/signal/signal_unix.go:27 +0x32

```