### PR TITLE
During encryption and decryption, use PBKDF2 key derivation

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -82,7 +82,7 @@ fi
 
 if [ "${ENCRYPTION_PASSWORD}" != "**None**" ]; then
   >&2 echo "Encrypting ${SRC_FILE}"
-  openssl enc -aes-256-cbc -in $SRC_FILE -out ${SRC_FILE}.enc -k $ENCRYPTION_PASSWORD
+  openssl enc -aes-256-cbc -pbkdf2 -iter 100000 -salt -in "$SRC_FILE" -out "${SRC_FILE}.enc" -k "$ENCRYPTION_PASSWORD"
   if [ $? != 0 ]; then
     >&2 echo "Error encrypting ${SRC_FILE}"
   fi

--- a/restore.sh
+++ b/restore.sh
@@ -94,7 +94,7 @@ if [[ "$LOCAL_FILE" == *.enc ]]; then
   
   echo "Decrypting backup file"
   DECRYPTED_PATH="${DOWNLOAD_PATH%.enc}"
-  openssl enc -aes-256-cbc -d -in $DOWNLOAD_PATH -out $DECRYPTED_PATH -k $ENCRYPTION_PASSWORD
+  openssl enc -aes-256-cbc -d -pbkdf2 -in "$DOWNLOAD_PATH" -out "$DECRYPTED_PATH" -k "$ENCRYPTION_PASSWORD"
   if [ $? != 0 ]; then
     echo "Error decrypting backup file. Check your encryption password."
     exit 1


### PR DESCRIPTION
When using the `ENCRYPTION_PASSWORD`, I'm getting errors like:

```
*** WARNING : deprecated key derivation used.
Using -iter or -pbkdf2 would be better.
```

I just added the required parameters in order to use the PBKDF2 key derivation.