### PR TITLE
Write dump files to /tmp and clean them up after upload

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -63,6 +63,8 @@ echo "Creating dump of ${POSTGRES_DATABASE} database from ${POSTGRES_HOST}..."
 if [ "$USE_CUSTOM_FORMAT" = "yes" ]; then
   SRC_FILE=/tmp/dump.dump
   DEST_FILE=${POSTGRES_DATABASE}_$(date +"%Y-%m-%dT%H:%M:%SZ").dump
+  rm -f $SRC_FILE
+
   if [ "${POSTGRES_DATABASE}" == "all" ]; then
     echo "ERROR: Custom format (-Fc) is not supported with pg_dumpall."
     exit 1
@@ -72,6 +74,8 @@ if [ "$USE_CUSTOM_FORMAT" = "yes" ]; then
 else
   SRC_FILE=/tmp/dump.sql.gz
   DEST_FILE=${POSTGRES_DATABASE}_$(date +"%Y-%m-%dT%H:%M:%SZ").sql.gz
+  rm -f $SRC_FILE
+  
   if [ "${POSTGRES_DATABASE}" == "all" ]; then
     pg_dumpall $POSTGRES_HOST_OPTS | $COMPRESSION_CMD > $SRC_FILE
   else
@@ -94,6 +98,7 @@ fi
 echo "Uploading dump to $S3_BUCKET"
 
 cat $SRC_FILE | aws $AWS_ARGS s3 cp - s3://$S3_BUCKET/$S3_PREFIX/$DEST_FILE || exit 2
+rm -f $SRC_FILE
 
 if [ "${DELETE_OLDER_THAN}" != "**None**" ]; then
   >&2 echo "Checking for files older than ${DELETE_OLDER_THAN}"

--- a/backup.sh
+++ b/backup.sh
@@ -61,7 +61,7 @@ POSTGRES_HOST_OPTS="-h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER $POSTG
 echo "Creating dump of ${POSTGRES_DATABASE} database from ${POSTGRES_HOST}..."
 
 if [ "$USE_CUSTOM_FORMAT" = "yes" ]; then
-  SRC_FILE=dump.dump
+  SRC_FILE=/tmp/dump.dump
   DEST_FILE=${POSTGRES_DATABASE}_$(date +"%Y-%m-%dT%H:%M:%SZ").dump
   if [ "${POSTGRES_DATABASE}" == "all" ]; then
     echo "ERROR: Custom format (-Fc) is not supported with pg_dumpall."
@@ -70,7 +70,7 @@ if [ "$USE_CUSTOM_FORMAT" = "yes" ]; then
     pg_dump -Fc $POSTGRES_HOST_OPTS $POSTGRES_DATABASE > $SRC_FILE
   fi
 else
-  SRC_FILE=dump.sql.gz
+  SRC_FILE=/tmp/dump.sql.gz
   DEST_FILE=${POSTGRES_DATABASE}_$(date +"%Y-%m-%dT%H:%M:%SZ").sql.gz
   if [ "${POSTGRES_DATABASE}" == "all" ]; then
     pg_dumpall $POSTGRES_HOST_OPTS | $COMPRESSION_CMD > $SRC_FILE


### PR DESCRIPTION
## Summary

Two small, related changes to `backup.sh`:

1. **Use `/tmp` for the intermediate dump file** (commit 1) instead of the container's working directory. This makes it easy to mount a larger volume at `/tmp` for databases whose dump exceeds the default container filesystem.
2. **Clean up the dump file after upload** (commit 2), so successive runs (especially with a persistent `/tmp` volume) don't accumulate stale dumps. Also adds defensive `rm -f` before each new dump in case a previous run failed before reaching the post-upload cleanup.

## Changes

- `backup.sh`: change `SRC_FILE` from `dump.dump` / `dump.sql.gz` to `/tmp/dump.dump` / `/tmp/dump.sql.gz`
- `backup.sh`: `rm -f $SRC_FILE` after the upload, and defensively before each dump invocation