### PR TITLE
Upgrade Alpine to 3.23 and PostgreSQL client to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22 AS build
+FROM alpine:3.23 AS build
 
 WORKDIR /app
 
@@ -12,12 +12,12 @@ RUN go mod init github.com/itbm/postgresql-backup-s3 \
 	&& go get github.com/robfig/cron/v3 \
 	&& go build -o out/go-cron
 
-FROM alpine:3.22
+FROM alpine:3.23
 LABEL maintainer="ITBM"
 
 RUN apk update \
 	&& apk upgrade \
-	&& apk add coreutils postgresql17-client aws-cli openssl pigz \
+	&& apk add coreutils postgresql18-client aws-cli openssl pigz \
 	&& rm -rf /var/cache/apk/*
 
 COPY --from=build /app/out/go-cron /usr/local/bin/go-cron


### PR DESCRIPTION
## Summary

Bumps both build and runtime images from `alpine:3.22` to `alpine:3.23`, and the PostgreSQL client from `postgresql17-client` to `postgresql18-client`. `postgresql18-client` is available in Alpine 3.23's default community repo, so no extra repo configuration is needed.